### PR TITLE
fix bugs

### DIFF
--- a/core/training/utils.py
+++ b/core/training/utils.py
@@ -42,7 +42,7 @@ def correct(output, target, topk=(1,)):
     correct = pred.eq(target.view(1, -1).expand_as(pred))
     res = []
     for k in topk:
-        correct_k = correct[:k].view(-1).sum(0, keepdim=True)
+        correct_k = correct[:k].contiguous().view(-1).sum(0, keepdim=True)
         res.append(correct_k)
     return res
 


### PR DESCRIPTION
add the .contiguous(). if not do so, will occur RuntimeError: "view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces)".